### PR TITLE
Add track duration filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-python app/main.py --source input/out4_.mp4 --output output --weights weights/yolov8x.pt --trail-len 30 --line 0.3 0 0.3 1
+Example usage:
+
+python app/main.py \
+    --source input/out4_.mp4 \
+    --output output \
+    --weights weights/yolov8x.pt \
+    --trail-len 30 \
+    --line 0.3 0 0.3 1 \
+    --min-frames 10 \
+    --min-displacement 20


### PR DESCRIPTION
## Summary
- filter tracks shorter than a minimum frame count and displacement
- expose CLI options `--min-frames` and `--min-displacement`
- document example usage with the new options

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c80f07ee4832cbdc3bde6a050bdf6